### PR TITLE
DTPORTAL-13655  update for PHP 7 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,14 @@
+dist: trusty
 language: php
-
 php:
-  - 5.3
-  - 5.4
-
+- 5.6
+- 7.2
+matrix:
+  fast_finish: true
+  allow_failures:
+  - php: 7.2
 before_script:
-  - curl -s http://getcomposer.org/installer | php
-  - php composer.phar install --dev
-
+  - composer install
 script:
   - redis-server tests/redis.conf
   - cd tests; phpunit

--- a/composer.json
+++ b/composer.json
@@ -19,22 +19,9 @@
             "email": "till@php.net"
         }
     ],
-    "repositories": [
-        {
-            "type": "package",
-            "package": {
-                "name": "zendframework/zendframework",
-                "version": "1.11.11",
-                "dist": {
-                    "url": "http://framework.zend.com/releases/ZendFramework-1.11.11/ZendFramework-1.11.11-minimal.zip",
-                    "type": "zip"
-                }
-            }
-        }
-    ],
     "require": {},
     "require-dev": {
-        "zendframework/zendframework": "1.11.*"
+        "zendframework/zendframework1": "1.12.20"
     },
     "autoload": {
         "psr-0":{

--- a/library/Rediska/Zend/Session/SaveHandler/Redis.php
+++ b/library/Rediska/Zend/Session/SaveHandler/Redis.php
@@ -25,7 +25,7 @@ require_once 'Zend/Session/SaveHandler/Exception.php';
 
 /**
  * Redis save handler for Zend_Session
- * 
+ *
  * @author Ivan Shumkov
  * @package Rediska
  * @subpackage ZendFrameworkIntegration
@@ -37,14 +37,14 @@ class Rediska_Zend_Session_SaveHandler_Redis extends Rediska_Options_RediskaInst
 {
     /**
      * Sessions set
-     * 
+     *
      * @var Rediska_Zend_Session_Set
      */
     protected $_set;
 
     /**
      * Configuration
-     * 
+     *
      * @var array
      */
     protected $_options = array(
@@ -54,7 +54,7 @@ class Rediska_Zend_Session_SaveHandler_Redis extends Rediska_Options_RediskaInst
 
     /**
      * Exception class name for options
-     * 
+     *
      * @var string
      */
     protected $_optionsException = 'Zend_Session_SaveHandler_Exception';
@@ -120,7 +120,8 @@ class Rediska_Zend_Session_SaveHandler_Redis extends Rediska_Options_RediskaInst
      */
     public function read($id)
     {
-        return $this->getRediska()->get($this->_getKeyName($id));
+        $sess = $this->getRediska()->get($this->_getKeyName($id));
+        return $sess ? $sess : '';
     }
 
     /**
@@ -160,7 +161,8 @@ class Rediska_Zend_Session_SaveHandler_Redis extends Rediska_Options_RediskaInst
             $this->_deleteSetOrThrowException($e);
         }
 
-        return $this->getRediska()->delete($this->_getKeyName($id));
+        $sess = $this->getRediska()->delete($this->_getKeyName($id));
+        return true;
     }
 
     /**


### PR DESCRIPTION
## [JIRA](https://dialogtech.atlassian.net/browse/DTPORTAL-13655)
Update the Rediska session handler to be PHP 7 compatible. Rediska is our main session handler for Portal and Organic so this change can impact a lot of different components. It will be important to do regression testing in Portal, calls and Organic.

Without updating the return values portal and organic will throw an error like the following:

```Uncaught: Zend_Session_Exception: Zend_Session::start() - /vagrant/CRBN/vendor/zendframework/zendframework1/library/Zend/Session.php(Line:482): Error #2 session_start(): Failed to read session data: user (path: /var/lib/php/session) in /vagrant/CRBN/vendor/zendframework/zendframework1/library/Zend/Session.php:495\nStack trace:\n#0 /vagrant/CRBN/vendor/zendframework/zendframework1/library/Zend/Session/Namespace.php(143): Zend_Session::start(true)\n#1 /vagrant/CRBN/portal/bootstrap.php(87): Zend_Session_Namespace->__construct()\n#2 /vagrant/CRBN/portal/ibp-page-init.php(2): require_once('/vagrant/CRBN/p...')\n#3 /vagrant/CRBN/portal/login.php(32): require_once('/vagrant/CRBN/p...')\n#4 {main}```

### Requires
- This library is included in CRBN and Organic deploys so once this is merged in any deploys to those systems will be affected. 

### Security Checklist
- [x] XSS
- [x] SQL injection

### Code Reviewers
@faraocious @jbuehring please review
@sfgeorge FYI