### PR TITLE
DTPORTAL-13655 Updates for PHP 7 compatibility

### DIFF
--- a/library/Rediska/Zend/Session/SaveHandler/Redis.php
+++ b/library/Rediska/Zend/Session/SaveHandler/Redis.php
@@ -25,7 +25,7 @@ require_once 'Zend/Session/SaveHandler/Exception.php';
 
 /**
  * Redis save handler for Zend_Session
- * 
+ *
  * @author Ivan Shumkov
  * @package Rediska
  * @subpackage ZendFrameworkIntegration
@@ -37,14 +37,14 @@ class Rediska_Zend_Session_SaveHandler_Redis extends Rediska_Options_RediskaInst
 {
     /**
      * Sessions set
-     * 
+     *
      * @var Rediska_Zend_Session_Set
      */
     protected $_set;
 
     /**
      * Configuration
-     * 
+     *
      * @var array
      */
     protected $_options = array(
@@ -54,7 +54,7 @@ class Rediska_Zend_Session_SaveHandler_Redis extends Rediska_Options_RediskaInst
 
     /**
      * Exception class name for options
-     * 
+     *
      * @var string
      */
     protected $_optionsException = 'Zend_Session_SaveHandler_Exception';
@@ -120,7 +120,8 @@ class Rediska_Zend_Session_SaveHandler_Redis extends Rediska_Options_RediskaInst
      */
     public function read($id)
     {
-        return $this->getRediska()->get($this->_getKeyName($id));
+        $sess = $this->getRediska()->get($this->_getKeyName($id));
+        return $sess ? $sess : '';
     }
 
     /**
@@ -160,7 +161,8 @@ class Rediska_Zend_Session_SaveHandler_Redis extends Rediska_Options_RediskaInst
             $this->_deleteSetOrThrowException($e);
         }
 
-        return $this->getRediska()->delete($this->_getKeyName($id));
+        $sess = $this->getRediska()->delete($this->_getKeyName($id));
+        return true;
     }
 
     /**


### PR DESCRIPTION
## [JIRA](https://dialogtech.atlassian.net/browse/DTPORTAL-13655)
Update the Rediska session handler to be PHP 7 compatible.

### Requires
- N/A

### Security Checklist
- [x] XSS
- [x] SQL injection

### Code Reviewers
@sfgeorge please review. We created a new `dialogtech/support/0.5.7` branch for the PHP 7 updates in this PR. I couldn't get composer to play nice by changing the version in CRBN and Ifbyphone at the same time. 

We'll need to coordinate with @jalubke when we update the Ifbyphone library for Organic deploys and updating the `composer.lock` file in CRBN. 